### PR TITLE
Trim emails before validating; Fix #4590

### DIFF
--- a/src/models/Users.php
+++ b/src/models/Users.php
@@ -89,7 +89,8 @@ class Users implements RestInterface
         // this might throw an exception if the team doesn't exist and we can't create it on the fly
         $teams = $Teams->getTeamsFromIdOrNameOrOrgidArray($teams);
         $TeamsHelper = new TeamsHelper((int) $teams[0]['id']);
-
+        
+        $email = trim($email);
         $EmailValidator = new EmailValidator($email, $Config->configArr['email_domain']);
         $EmailValidator->validate();
 


### PR DESCRIPTION
I didn't do much aside from following your approach in trimming names in [`b22e24`](https://github.com/elabftw/elabftw/commit/b22e24ba0efdfa174478cfa6936177bd2db1d4ff). Probably a better better approach would be doing the trim in `src/services/EmailValidator.php`.